### PR TITLE
Add in-memory session store for drawbridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ authentication or authorization to some application-specific role, those
 prerequisites will apply just as with any other Ring handler in the same
 context.
 
-Some things to be aware of when using `cemerick.drawbridge/ring-handler`: 
+Some things to be aware of when using `cemerick.drawbridge/ring-handler`:
 
  * It requires `GET` and `POST` requests
    to be routed to whatever URI to which it is mapped; other request
@@ -75,7 +75,6 @@ Some things to be aware of when using `cemerick.drawbridge/ring-handler`:
    * `keyword-params`
    * `nested-params`
    * `wrap-params`
-   * `wrap-session`
 
 Especially if you are going to be connecting to your webapp's nREPL
 endpoint with a client that uses Drawbridge's own HTTP/HTTPS client
@@ -111,7 +110,7 @@ yet been addressed at all.
 ## Need Help?
 
 Send a message to the [clojure-tools](http://groups.google.com/group/clojure-tools)
-mailing list, or ping `cemerick` on freenode irc or 
+mailing list, or ping `cemerick` on freenode irc or
 [twitter](http://twitter.com/cemerick) if you have questions
 or would like to contribute patches.
 

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
-(defproject com.cemerick/drawbridge "0.0.6"
+(defproject racehub/drawbridge "0.1.0"
   :description "HTTP transport support for Clojure's nREPL implemented as a Ring handler."
-  :url "http://github.com/cemerick/drawbridge"
+  :url "http://github.com/racehub/drawbridge"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.7.0-alpha2"]
@@ -10,7 +10,6 @@
 
                  ;; client
                  [clj-http "1.0.0"]]
-  :profiles {:dev {:dependencies [[ring "1.3.0"]]
-                   :plugins [[lein-clojars "0.9.0"]]}
+  :profiles {:dev {:dependencies [[ring "1.3.0"]]}
              :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}}
   :main ^{:skip-aot true} cemerick.drawbridge)

--- a/project.clj
+++ b/project.clj
@@ -3,16 +3,14 @@
   :url "http://github.com/cemerick/drawbridge"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.2.0"]
-                 [org.clojure/tools.nrepl "0.2.0-beta5"]
-                 [ring/ring-core "1.0.2"]
-                 [cheshire "3.0.0"]
+  :dependencies [[org.clojure/clojure "1.7.0-alpha2"]
+                 [org.clojure/tools.nrepl "0.2.5"]
+                 [ring/ring-core "1.3.0"]
+                 [cheshire "5.3.1"]
 
                  ;; client
-                 [clj-http "0.3.6"]]
-  :dev-dependencies [[ring "1.0.0"]]
-  :profiles {:dev {:dependencies [[ring "1.0.0"]]
+                 [clj-http "1.0.0"]]
+  :profiles {:dev {:dependencies [[ring "1.3.0"]]
                    :plugins [[lein-clojars "0.9.0"]]}
-             :1.3 {:dependencies [[org.clojure/clojure "1.3.0"]]}
-             :1.4 {:dependencies [[org.clojure/clojure "1.4.0"]]}}
+             :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}}
   :main ^{:skip-aot true} cemerick.drawbridge)


### PR DESCRIPTION
Fixes #15, and #11. This pull req adds an in-memory store wrapper with a different default key. The session that Drawbridge sets gets slurped up by the in-memory store, which sets a cookie. Any session middleware further up the chain won't see the non-serializable nREPL session values, and higher middleware such as Friend are free to set whatever keys they want in the standard, user-specified session.